### PR TITLE
Indicate in the response which modules we know about and can symbolicate.

### DIFF
--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -108,14 +108,19 @@ class RequestHandler(BaseHTTPRequestHandler):
     try:
       self.sendHeaders(200)
 
-      response = []
+      response = { 'symbolicatedStacks': [] }
       for stackIndex in range(len(request.stacks)):
         symbolicatedStack = request.Symbolicate(stackIndex)
 
         # Free up memory ASAP
         request.stacks[stackIndex] = []
 
-        response.append(symbolicatedStack)
+        response['symbolicatedStacks'].append(symbolicatedStack)
+
+      response['knownModules'] = request.knownModules[:]
+      if not request.includeKnownModulesInResponse:
+        response = response['symbolicatedStacks']
+
       request.Reset()
 
       LogTrace("Response: " + json.dumps(response))


### PR DESCRIPTION
For users of the symbol server it can be useful to know what modules the symbol server knows about. The user can then, on demand, create breakpad symbol files for those local libraries that the symbol server doesn't know about. These symbol dumps can then be included in a local symbol server instance, for example.

This changeset adds the ability to specify "version": 4 in the request, which changes the response JSON from a list of symbolicated stacks to an object with two properties: { "symbolicatedStacks": [[...][...]], "knownModules": [true, false, false, true] }. The values in the knownModules list are in the same order as in the "memoryMap" request field, and indicate whether each module in the memoryMap was found, either locally or on the forwarded symbol server.