### PR TITLE
Add support for fetching symbols over HTTP

### DIFF
--- a/sample.ini
+++ b/sample.ini
@@ -22,11 +22,6 @@ prefetchThreshold = 48
 
 prefetchMaxSymbolsPerLib = 3
 
-defaultApp = Firefox
-
-defaultOs = Windows
-
-
 
 [SymbolPaths]
 

--- a/sample.ini
+++ b/sample.ini
@@ -16,12 +16,6 @@ enableTracing = 0
 
 maxCacheEntries = 2000000
 
-prefetchInterval = 12
-
-prefetchThreshold = 48
-
-prefetchMaxSymbolsPerLib = 3
-
 
 [SymbolPaths]
 

--- a/sample.ini
+++ b/sample.ini
@@ -16,6 +16,8 @@ enableTracing = 0
 
 maxCacheEntries = 2000000
 
+mruSymbolStateFile = /tmp/snappy-mru-symbols.json
+maxMRUSymbolsPersist = 10
 
 [SymbolPaths]
 

--- a/sample.ini
+++ b/sample.ini
@@ -26,3 +26,6 @@ Firefox = /mnt/netapp/breakpad/symbols_ffx
 Windows = /mnt/netapp/breakpad/symbols_os
 
 Thunderbird = /mnt/netapp/breakpad/symbols_tbrd
+
+[SymbolURLs]
+MozillaS3 = https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/

--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -30,12 +30,6 @@ gOptions = {
   # Maximum number of symbol files to keep in memory
   # "maxCacheEntries": 10 * 1000 * 1000,
   "maxCacheEntries": 100,
-  # Frequency of checking for recent symbols to cache (in hours)
-  "prefetchInterval": 12,
-  # Oldest file age to prefetch (in hours)
-  "prefetchThreshold": 48,
-  # Maximum number of library versions to pre-fetch per library
-  "prefetchMaxSymbolsPerLib": 3,
   # Paths to .SYM files
   "symbolPaths": [
     # Location of Firefox library symbols
@@ -181,7 +175,7 @@ def Main():
   # Create the .SYM cache manager singleton
   gSymFileManager = SymFileManager(gOptions)
 
-  # Prefetch recent symbols + start the periodic prefetch callbacks
+  # Prefetch recent symbols
   gSymFileManager.PrefetchRecentSymbolFiles()
 
   LogMessage("Starting server with the following options:\n" + str(gOptions))
@@ -194,8 +188,6 @@ def Main():
     httpd.serve_forever()
   except KeyboardInterrupt:
     LogMessage("Received SIGINT, stopping...")
-
-  gSymFileManager.StopPrefetchTimer()
 
   httpd.server_close()
   LogMessage("Server stopped - " + gOptions['hostname'] + ":" + str(gOptions['portNumber']))

--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -42,6 +42,10 @@ gOptions = {
     os.path.join(os.getcwd(), "symbols_tbrd"),
     # Location of Windows library symbols
     os.path.join(os.getcwd(), "symbols_os"),
+  ],
+  # URLs to symbol stores
+  "symbolURLs": [
+    'https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/',
   ]
 }
 
@@ -143,8 +147,8 @@ def ReadConfigFile():
       return False
 
   # Check for section names
-  if set(configParser.sections()) != set(["General", "SymbolPaths"]):
-    LogError("Config file should be made up of two sections: 'General' and 'SymbolPaths'")
+  if set(configParser.sections()) != set(["General", "SymbolPaths", "SymbolURLs"]):
+    LogError("Config file should be made up of three sections: 'General', 'SymbolPaths' and 'SymbolURLs'")
     return False
 
   generalSectionOptions = configParser.items("General")
@@ -160,11 +164,16 @@ def ReadConfigFile():
         return False
     gOptions[option] = value
 
-  # Get the list of symbol paths from the config file
+  # Get the list of symbol paths and URLs from the config file
   configPaths = configParser.items("SymbolPaths")
   if configPaths:
     # Drop defaults if config file entries exist
     gOptions["symbolPaths"] = [path for name, path in configPaths]
+
+  # Get the list of symbol paths from the config file
+  configURLs = configParser.items("SymbolURLs")
+  if configURLs:
+    gOptions["symbolURLs"] = [url for name, url in configURLs]
 
   return True
 

--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -30,6 +30,10 @@ gOptions = {
   # Maximum number of symbol files to keep in memory
   # "maxCacheEntries": 10 * 1000 * 1000,
   "maxCacheEntries": 100,
+  # File in which to persist the list of most-recently-used symbols.
+  "mruSymbolStateFile": "/tmp/snappy-mru-symbols.json",
+  # Maximum number of symbol files to persist in the state file between runs.
+  "maxMRUSymbolsPersist": 10,
   # Paths to .SYM files
   "symbolPaths": [
     # Location of Firefox library symbols


### PR DESCRIPTION
We're moving Socorro's symbol store to S3, and we already have the S3 bucket populated, so we can switch the snappy server over now in advance of the eventual demise of the NFS mount.

The first few changes here are refactoring to make the last change easier. I removed some functionality (app name to symbol path mapping, timed symbol prefetching), and rewrote one piece of functionality (symbol prefetching on startup).