### PR TITLE
Address review comments from pull request #19

### DIFF
--- a/symFileManager.py
+++ b/symFileManager.py
@@ -162,11 +162,13 @@ class SymFileManager:
     try:
       mruSymbols = []
       with open(self.sOptions["mruSymbolStateFile"], "rb") as f:
-        mruSymbols = json.load(f)["symbols"]
+        mruSymbols = json.load(f)["symbols"][:self.sOptions["maxMRUSymbolsPersist"]]
       LogMessage("Going to prefetch %d recent symbol files" % len(mruSymbols))
       self.sUpdateMRUFile = False
       for libName, breakpadId in mruSymbols:
-        self.GetLibSymbolMap(libName, breakpadId)
+        sym = self.GetLibSymbolMap(libName, breakpadId)
+        if sym is None:
+          LogTrace("Failed to prefetch symbols for (%s,%s)" % (libName, breakpadId))
       LogMessage("Finished prefetching recent symbol files")
     except IOError:
       LogError("Error reading MRU symbols state file")

--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -45,7 +45,7 @@ gOptions = {
   ],
   # URLs to symbol stores
   "symbolURLs": [
-    'https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/',
+    "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/",
   ]
 }
 
@@ -164,13 +164,13 @@ def ReadConfigFile():
         return False
     gOptions[option] = value
 
-  # Get the list of symbol paths and URLs from the config file
+  # Get the list of symbol paths from the config file
   configPaths = configParser.items("SymbolPaths")
   if configPaths:
     # Drop defaults if config file entries exist
     gOptions["symbolPaths"] = [path for name, path in configPaths]
 
-  # Get the list of symbol paths from the config file
+  # Get the list of symbol URLs from the config file
   configURLs = configParser.items("SymbolURLs")
   if configURLs:
     gOptions["symbolURLs"] = [url for name, url in configURLs]

--- a/symbolicationWebService.py
+++ b/symbolicationWebService.py
@@ -36,12 +36,8 @@ gOptions = {
   "maxMRUSymbolsPersist": 10,
   # Paths to .SYM files
   "symbolPaths": [
-    # Location of Firefox library symbols
-    os.path.join(os.getcwd(), "symbols_ffx"),
-    # Location of Thunderbird library symbols
-    os.path.join(os.getcwd(), "symbols_tbrd"),
-    # Location of Windows library symbols
-    os.path.join(os.getcwd(), "symbols_os"),
+    # Default to empty so users don't have to list anything in their config
+    # file to override the defaults.
   ],
   # URLs to symbol stores
   "symbolURLs": [


### PR DESCRIPTION
This should address all of your comments from #19 (except updating the README, I'm not sure what to put there). There's also a followup changeset to remove the default symbolPaths, since as-written the code won't override the defaults if you have an empty [SymbolPaths] section in the config file, and we're going to want to run the server with no local symbol paths in production.